### PR TITLE
Make initialization of lambda requests easier

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,16 +25,15 @@ Usage
 
 .. code-block:: python
 
-    >>> import requests
-    >>> from lambda_requests import LambdaAdapter
-    >>> la = requests.Session()
-    >>> la.mount("httplambda://", LambdaAdapter())
-    >>> la.get("httplambda://flaskexp-test/test/foo")
+    >>> import lambda_requests
+    >>> la = lambda_requests.Session()
+    >>> la.get("http+lambda://flaskexp-test/test/foo")
     <Response [200]>
 
-In short mount `LambdaAdapter` to requests session then access your lambdas by
-using url of this format `httplambda://{name-of-lambda-function}/...` then use
-`requests`_ as you normally would; get, post, query strings, form data ... etc.
+In short, start a lambda_requests.Session() and then access you lambdas by
+passing `http+lambda://{name-of-lambda-function}/...` as the uri to the common
+`requests`_  methods such as `get`, `post` and the usual parameters such as query
+strings, form data and so on.
 
 Lambda authorization is configured via `boto3`_, and can be set up using
 `environment variables`_ or a `configuration file`_. Configuration file is
@@ -48,7 +47,7 @@ recommended. Example credential file ~/.aws/credentials:
 
 Similar to authorization, region can be configured either via the `environment
 variable`_ `AWS_DEFAULT_REGION`, `configuration file`_. Region can also be set
-on initialization of LambdaAdapter(region:'us-west-2'). Example configuration
+on initialization of `Session(region="us-west-2")`. Example configuration
 file ~/.aws/config:
 
 .. code-block:: ini

--- a/lambda_requests/__init__.py
+++ b/lambda_requests/__init__.py
@@ -3,4 +3,8 @@ __author__ = """Ilya Sukhanov"""
 __email__ = "ilya@sukhanov.net"
 __version__ = "0.1.0"
 
-from lambda_requests.lambda_request import LambdaAdapter  # noqa
+from lambda_requests.lambda_request import (  # noqa
+    DEFAULT_SCHEME,
+    LambdaAdapter,
+    Session,
+)

--- a/lambda_requests/lambda_request.py
+++ b/lambda_requests/lambda_request.py
@@ -6,9 +6,12 @@ from io import BytesIO
 from urllib.parse import parse_qs, urlparse
 
 import boto3
+import requests
 from requests.adapters import BaseAdapter, Response
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_SCHEME = "http+lambda://"
 
 
 def _lambda_query_string(url):
@@ -20,6 +23,12 @@ def decode_payload(lambda_response, field):
         return BytesIO(base64.b64decode(lambda_response[field]))
     else:
         return BytesIO(lambda_response[field].encode("utf-8"))
+
+
+class Session(requests.Session):
+    def __init__(self, url_scheme=None, region=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mount(url_scheme or DEFAULT_SCHEME, LambdaAdapter(region=region))
 
 
 class LambdaAdapter(BaseAdapter):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="lambda_requests",
-    version="1.0",
+    version="1.1",
     description="Use Requests to invoke AWS Lambdas",
     author="Ilya Sukhanov",
     author_email="ilya@sukhanov.net",

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import DEFAULT, patch
 
-LAMBDA_URL_PREFIX = "httplambda://flaskexp-test"
+LAMBDA_URL_PREFIX = "http+lambda://flaskexp-test"
 HTTP_URL_PREFIX = "https://qrq3869e2e.execute-api.us-west-2.amazonaws.com/test/"
 BINARY_PAYLOAD = bytes([0xDE, 0xAD, 0xBE, 0xEF] * 100)
 UNICODE_PAYLOAD = u"\u2620\U0001F42E" * 100

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -4,7 +4,7 @@ from io import BytesIO, StringIO
 
 import requests
 
-from lambda_requests import LambdaAdapter
+import lambda_requests
 from tests.base import (
     BINARY_PAYLOAD,
     LAMBDA_URL_PREFIX,
@@ -16,8 +16,7 @@ from tests.base import (
 class TestLambda(PatcherBase):
     def setUp(self):
         self.http_accessor = requests.Session()
-        self.lambda_accessor = requests.Session()
-        self.lambda_accessor.mount("httplambda://", LambdaAdapter())
+        self.lambda_accessor = lambda_requests.Session()
         self.boto3 = self.add_patcher("lambda_requests.lambda_request.boto3")
 
     def extract_sent_payload(self, key):

--- a/tests/test_lambda_integration.py
+++ b/tests/test_lambda_integration.py
@@ -2,7 +2,7 @@ from io import BytesIO, StringIO
 
 import requests
 
-from lambda_requests import LambdaAdapter
+import lambda_requests
 from tests.base import (
     BINARY_PAYLOAD,
     HTTP_URL_PREFIX,
@@ -22,8 +22,7 @@ def _seek_reset_request(accessor, url_path, *args, **kwargs):
 class TestLambdaIntegration(PatcherBase):
     def setUp(self):
         self.http_accessor = requests.Session()
-        self.lambda_accessor = requests.Session()
-        self.lambda_accessor.mount("httplambda://", LambdaAdapter(region="us-west-2"))
+        self.lambda_accessor = lambda_requests.Session()
 
     def post_both(self, url_path, *args, **kwargs):
         return (


### PR DESCRIPTION
This is done by providing a convenience Session() object which mounts the
LambdaAdapter().

This is inspired by https://github.com/msabramo/requests-unixsocket