### PR TITLE
Provide `resource` in lambda payload

### DIFF
--- a/lambda_requests/lambda_request.py
+++ b/lambda_requests/lambda_request.py
@@ -68,6 +68,7 @@ class LambdaAdapter(BaseAdapter):
             )
             base64_encoded = True
         return {
+            "resource": urlparse(request.path_url).path,
             "httpMethod": request.method,
             "path": urlparse(request.path_url).path,
             "pathParameters": "",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="lambda_requests",
-    version="1.3",
+    version="1.4",
     description="Use Requests to invoke AWS Lambdas",
     long_description=open("README.rst").read().strip(),
     author="Ilya Sukhanov",


### PR DESCRIPTION
`resource` is used by Mangum to identify AwsApiGateway events.

See https://github.com/jordaneremieff/mangum/issues/193 for more details.